### PR TITLE
Call initialize methods with new props

### DIFF
--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -136,11 +136,11 @@ export class Table extends React.Component {
         this.initializeFilters(props);
     }
 
-    initializeFilters() {
+    initializeFilters(props) {
         this._filterable = {};
         // Transform filterable properties into a more friendly list
-        for (let i in this.props.filterable) {
-            let column = this.props.filterable[i];
+        for (let i in props.filterable) {
+            let column = props.filterable[i];
             let columnName, filterFunction;
 
             if (column instanceof Object) {
@@ -165,11 +165,11 @@ export class Table extends React.Component {
         }
     }
 
-    initializeSorts() {
+    initializeSorts(props) {
         this._sortable = {};
         // Transform sortable properties into a more friendly list
-        for (let i in this.props.sortable) {
-            let column = this.props.sortable[i];
+        for (let i in props.sortable) {
+            let column = props.sortable[i];
             let columnName, sortFunction;
 
             if (column instanceof Object) {


### PR DESCRIPTION
Both componentWillMount and componentWillReceiveProps call initialize
with props argument. Initialize did not pass these props on to
initializeFilters and initializeSorts which instad used this.props.
In the case of componentWillReceiveProps, the correct props to use to
initialize is nextProps not this.props.