### PR TITLE
On receiving new props, use defaultSort if sortBy is false

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1241,10 +1241,16 @@ window.ReactDOM["default"] = window.ReactDOM;
             }
         }, {
             key: 'updateCurrentSort',
-            value: function updateCurrentSort(sortBy) {
+            value: function updateCurrentSort(sortBy, defaultSort) {
+                var currentSort = null;
                 if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
+                    currentSort = sortBy;
+                } else if (sortBy == false && defaultSort != undefined) {
+                    currentSort = defaultSort;
+                }
 
-                    this.setState({ currentSort: this.getCurrentSort(sortBy) });
+                if (currentSort) {
+                    this.setState({ currentSort: this.getCurrentSort(curentSort) });
                 }
             }
         }, {
@@ -1266,7 +1272,7 @@ window.ReactDOM["default"] = window.ReactDOM;
             value: function componentWillReceiveProps(nextProps) {
                 this.initialize(nextProps);
                 this.updateCurrentPage(nextProps.currentPage);
-                this.updateCurrentSort(nextProps.sortBy);
+                this.updateCurrentSort(nextProps.sortBy, nextProps.defaultSort);
                 this.sortByCurrentSort();
                 this.filterBy(nextProps.filterBy);
             }

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -272,10 +272,16 @@ var Table = (function (_React$Component) {
         }
     }, {
         key: 'updateCurrentSort',
-        value: function updateCurrentSort(sortBy) {
+        value: function updateCurrentSort(sortBy, defaultSort) {
+            var currentSort = null;
             if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
+                currentSort = sortBy;
+            } else if (sortBy == false && defaultSort != undefined) {
+                currentSort = defaultSort;
+            }
 
-                this.setState({ currentSort: this.getCurrentSort(sortBy) });
+            if (currentSort) {
+                this.setState({ currentSort: this.getCurrentSort(curentSort) });
             }
         }
     }, {
@@ -297,7 +303,7 @@ var Table = (function (_React$Component) {
         value: function componentWillReceiveProps(nextProps) {
             this.initialize(nextProps);
             this.updateCurrentPage(nextProps.currentPage);
-            this.updateCurrentSort(nextProps.sortBy);
+            this.updateCurrentSort(nextProps.sortBy, nextProps.defaultSort);
             this.sortByCurrentSort();
             this.filterBy(nextProps.filterBy);
         }

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -230,12 +230,20 @@ export class Table extends React.Component {
         };
     }
 
-    updateCurrentSort(sortBy) {
+    updateCurrentSort(sortBy, defaultSort) {
+        var currentSort = null;
         if (sortBy !== false &&
             sortBy.column !== this.state.currentSort.column &&
                 sortBy.direction !== this.state.currentSort.direction) {
+            currentSort = sortBy;
+        }
 
-            this.setState({ currentSort: this.getCurrentSort(sortBy) });
+        else if (sortBy == false && defaultSort != undefined) {
+            currentSort = defaultSort;
+        }
+
+        if (currentSort) {
+            this.setState({currentSort: this.getCurrentSort(curentSort)});
         }
     }
 
@@ -254,7 +262,7 @@ export class Table extends React.Component {
     componentWillReceiveProps(nextProps) {
         this.initialize(nextProps);
         this.updateCurrentPage(nextProps.currentPage)
-        this.updateCurrentSort(nextProps.sortBy);
+        this.updateCurrentSort(nextProps.sortBy, nextProps.defaultSort);
         this.sortByCurrentSort();
         this.filterBy(nextProps.filterBy);
     }


### PR DESCRIPTION
If columns have changed on receiving new props, this.state.currentSort
may reference a column which no longer exists. It should then be
updated to nextProps.defaultSort if it exists.