### PR TITLE
On receiving new props, use defaultSort if sortBy is false

### DIFF
--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -243,7 +243,7 @@ export class Table extends React.Component {
         }
 
         if (currentSort) {
-            this.setState({currentSort: this.getCurrentSort(curentSort)});
+            this.setState({currentSort: this.getCurrentSort(currentSort)});
         }
     }
 


### PR DESCRIPTION
If columns have changed on receiving new props, this.state.currentSort
may reference a column which no longer exists. It should then be
updated to nextProps.defaultSort if it exists.